### PR TITLE
Handle lack of setuptools more gracefully

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-from setuptools import setup, find_packages
-
+try:
+    from setuptools import setup, find_packages
+except ImportError:
+    print "You need to install setuptools to continue"
 setup(
     name='beluga',
     version='1.0.0',


### PR DESCRIPTION
When running setup.py on my Ubuntu 16.04 LTS system, I had to run sudo apt-get install python-setuptools to continue. This handles an error on import more gracefully and suggests that the user installs the package to continue.
